### PR TITLE
Maybe fixing things...

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,7 +65,7 @@ JB :
   #   http://s3.amazonaws.com/yoursite/themes/watermelon
   #   /assets
   #
-  ASSET_PATH : false
+  ASSET_PATH : "/assets/themes/bootstrap-3/"
 
   # These paths are to the main pages Jekyll-Bootstrap ships with.
   # Some JB helpers refer to these paths; change them here if needed.

--- a/_includes/themes/bootstrap-3/post.html
+++ b/_includes/themes/bootstrap-3/post.html
@@ -5,7 +5,7 @@
 <div class="row post-full">
   <div class="col-xs-12">
     <div class="date">
-      <span>{{ page.date | date_to_long_string }}</span>
+      <span>{{ page.date | date: "%-d %B %Y" }}</span>
     </div>
     <div class="content">
       {{ content }}


### PR DESCRIPTION
Had a bit of a play around with the site on my laptop. 

Had to tweak _includes/themes/bootstrap-3/post.html to get it to build cleanly, which then showed the lack of styling...

That seems to be because it doesn't find the bootstrap assets, because it's not picking up the theme name for them properly (line 23 of _includes/JB/setup should set that, but page.theme.name seems to be an empty string there).  Couldn't work out what was wrong with the page.theme.name, but setting the asset path explicitly in _config.yml works round that (and shouldn't cause any problems until you want to change themes)
